### PR TITLE
add extension  yank-note-extension-vim-mode

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -10,6 +10,7 @@
     { "id": "@yank-note/extension-sublime-merge", "version": "1.0.5" }
   ],
   "registry": [ 
-    { "id": "yank-note-extension-theme-yanser", "version": "1.0.4" }
+    { "id": "yank-note-extension-theme-yanser", "version": "1.0.4" },
+    { "id": "yank-note-extension-vim-mode", "version": "0.0.1" }
   ]
 }

--- a/extensions.json
+++ b/extensions.json
@@ -11,6 +11,6 @@
   ],
   "registry": [ 
     { "id": "yank-note-extension-theme-yanser", "version": "1.0.4" },
-    { "id": "yank-note-extension-vim-mode", "version": "0.0.1" }
+    { "id": "yank-note-extension-vim-mode", "version": "1.0.0" }
   ]
 }


### PR DESCRIPTION
## 基础信息

- 名称: vim插件
- 包名: yank-note-extension-vim-mode
- 版本: 0.0.1
- 项目地址: https://github.com/zhyipeng/yank-note-extension-vim-mode

## 更新日志
- 通过 cdn 加载 monaco-vim 实现, 作为 yn 快捷键重构前的临时解决方案.

