### PR TITLE
vim-mode插件更新到 1.0.2 版本

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -11,6 +11,6 @@
   ],
   "registry": [ 
     { "id": "yank-note-extension-theme-yanser", "version": "1.0.4" },
-    { "id": "yank-note-extension-vim-mode", "version": "1.0.1" }
+    { "id": "yank-note-extension-vim-mode", "version": "1.0.2" }
   ]
 }


### PR DESCRIPTION
增加了vim状态栏

## 基础信息

- 名称: vim-mode
- 包名: yank-note-extension-vim-mode
- 版本: 1.0.2
- 项目地址: https://github.com/zhyipeng/yank-note-extension-vim-mode

## 更新日志
增加 vim 状态栏

## 相关提交
https://github.com/zhyipeng/yank-note-extension-vim-mode/commit/d6778564cf9d879032a4f3a51f1e27f757e1e673