### PR TITLE
vim插件更新1.0.3

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -15,7 +15,7 @@
   "registry": [
     { "id": "yank-note-extension-theme-yanser", "version": "1.0.5" },
     { "id": "yank-note-extension-view-reverse-yanser", "version": "1.0.1" },
-    { "id": "yank-note-extension-vim-mode", "version": "1.0.2" },
+    { "id": "yank-note-extension-vim-mode", "version": "1.0.3" },
     { "id": "yank-note-extension-tool-bar", "version": "1.0.0" }
   ]
 }


### PR DESCRIPTION
## 基础信息

- 名称: vim插件
- 包名: vim-mode
- 版本: 1.0.3
- 项目地址: https://github.com/zhyipeng/yank-note-extension-vim-mode

## 更新日志
增加开关, 默认开启: 工具-vim

## 相关提交
[9f1c38affb2019fd87640bd224e657abd7f3e3ac](https://github.com/zhyipeng/yank-note-extension-vim-mode/commit/9f1c38affb2019fd87640bd224e657abd7f3e3ac)
