### PR TITLE
vim-mode 插件升级 1.0.5 版本

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -16,7 +16,7 @@
   "registry": [
     { "id": "yank-note-extension-theme-yanser", "version": "1.1.0" },
     { "id": "yank-note-extension-view-reverse-yanser", "version": "1.0.2" },
-    { "id": "yank-note-extension-vim-mode", "version": "1.0.4" },
+    { "id": "yank-note-extension-vim-mode", "version": "1.0.5" },
     { "id": "yank-note-extension-tool-bar", "version": "1.0.0" }
   ]
 }


### PR DESCRIPTION
适配 YankNote 3.35.0 版本不兼容改动

## 基础信息

- 名称: vim-mode 插件
- 包名: yank-note-extension-vim-mode
- 版本: 1.0.5
- 项目地址: https://github.com/zhyipeng/yank-note-extension-vim-mode

## 更新日志
适配 YankNote 3.35.0 版本不兼容改动

