### PR TITLE
snippet插件升级到 1.0.2

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -21,6 +21,6 @@
     { "id": "yank-note-extension-view-reverse-yanser", "version": "2.3.0" },
     { "id": "yank-note-extension-vim-mode", "version": "1.0.5" },
     { "id": "yank-note-extension-tool-bar", "version": "1.0.0" },
-    { "id": "yank-note-extension-snippet", "version": "1.0.1" }
+    { "id": "yank-note-extension-snippet", "version": "1.0.2" }
   ]
 }


### PR DESCRIPTION
## 基础信息

- 名称: 文本片段插件
- 包名: yank-note-extension-snippet
- 版本: 1.0.2
- 项目地址: https://github.com/zhyipeng/yank-note-extension-snippet

## 更新日志
- 变更存储方式, 以解决同设备多浏览器间同步问题
