### PR TITLE
vim extension upgrade to 1.0.6

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -19,7 +19,7 @@
   "registry": [
     { "id": "yank-note-extension-theme-yanser", "version": "2.0.0" },
     { "id": "yank-note-extension-view-reverse-yanser", "version": "2.3.0" },
-    { "id": "yank-note-extension-vim-mode", "version": "1.0.5" },
+    { "id": "yank-note-extension-vim-mode", "version": "1.0.6" },
     { "id": "yank-note-extension-tool-bar", "version": "1.0.0" },
     { "id": "yank-note-extension-snippet", "version": "1.0.3" }
   ]


### PR DESCRIPTION
## 基础信息

- 名称: vim 插件
- 包名: yank-note-extension-vim-mode
- 版本: 1.0.6
- 项目地址: https://github.com/zhyipeng/yank-note-extension-vim-mode

## 更新日志
* 适配 Yank Note 3.58.0 版本 ([204833b](https://github.com/zhyipeng/yank-note-extension-vim-mode/commit/204833bc919e8519a17c5351c142f5dc635a1d74))

