### PR TITLE
vim extension upgrade to 1.0.7

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -19,7 +19,7 @@
   "registry": [
     { "id": "yank-note-extension-theme-yanser", "version": "2.0.0" },
     { "id": "yank-note-extension-view-reverse-yanser", "version": "2.3.0" },
-    { "id": "yank-note-extension-vim-mode", "version": "1.0.6" },
+    { "id": "yank-note-extension-vim-mode", "version": "1.0.7" },
     { "id": "yank-note-extension-tool-bar", "version": "1.0.0" },
     { "id": "yank-note-extension-snippet", "version": "1.0.3" }
   ]


### PR DESCRIPTION
## 基础信息

- 名称: vim插件
- 包名: yank-note-extension-vim-mode
- 版本:1.0.7
- 项目地址: https://github.com/zhyipeng/yank-note-extension-vim-mode

## 更新日志
* 展示出命令输入框 ([fd58c7a](https://github.com/zhyipeng/yank-note-extension-vim-mode/commit/fd58c7a09d701ef67e2198ba77c2959fec734eff))
* 调整 action 名字 ([52f890a](https://github.com/zhyipeng/yank-note-extension-vim-mode/commit/52f890a8f4e33b1ca31ab7f2b1e1b3bb2718f3d6))

## 相关提交
<可选>
