### PR TITLE
vim extension upgrade to 1.0.8

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -19,7 +19,7 @@
   "registry": [
     { "id": "yank-note-extension-theme-yanser", "version": "2.0.0" },
     { "id": "yank-note-extension-view-reverse-yanser", "version": "2.3.0" },
-    { "id": "yank-note-extension-vim-mode", "version": "1.0.8" },
+    { "id": "yank-note-extension-vim-mode", "version": "1.1.0" },
     { "id": "yank-note-extension-tool-bar", "version": "1.0.0" },
     { "id": "yank-note-extension-snippet", "version": "1.0.3" }
   ]

--- a/extensions.json
+++ b/extensions.json
@@ -19,7 +19,7 @@
   "registry": [
     { "id": "yank-note-extension-theme-yanser", "version": "2.0.0" },
     { "id": "yank-note-extension-view-reverse-yanser", "version": "2.3.0" },
-    { "id": "yank-note-extension-vim-mode", "version": "1.0.7" },
+    { "id": "yank-note-extension-vim-mode", "version": "1.0.8" },
     { "id": "yank-note-extension-tool-bar", "version": "1.0.0" },
     { "id": "yank-note-extension-snippet", "version": "1.0.3" }
   ]


### PR DESCRIPTION
## 基础信息

- 名称: vim插件
- 包名: yank-note-extension-vim-mode
- 版本: 1.0.8
- 项目地址: https://github.com/zhyipeng/yank-note-extension-vim-mode

## 更新日志
### Features

* 支持keymaps ([de27cba](https://github.com/zhyipeng/yank-note-extension-vim-mode/commit/de27cbaadaa4536d4b2ada615289205851fe7032))

