### PR TITLE
add yank-note-extension-math and yank-note-extension-background

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -30,6 +30,7 @@
     { "id": "yank-note-extension-tool-bar", "version": "1.0.0" },
     { "id": "yank-note-extension-snippet", "version": "1.0.3" },
     { "id": "yank-note-extension-docsify", "version": "0.0.3" },
-    { "id": "yank-note-extension-math", "version": "0.2.2" }
+    { "id": "yank-note-extension-math", "version": "0.2.2" },
+    { "id": "yank-note-extension-background", "version": "0.1.0" }
   ]
 }

--- a/extensions.json
+++ b/extensions.json
@@ -29,6 +29,7 @@
     { "id": "yank-note-extension-vim-mode", "version": "1.1.0" },
     { "id": "yank-note-extension-tool-bar", "version": "1.0.0" },
     { "id": "yank-note-extension-snippet", "version": "1.0.3" },
-    { "id": "yank-note-extension-docsify", "version": "0.0.3" }
+    { "id": "yank-note-extension-docsify", "version": "0.0.3" },
+    { "id": "yank-note-extension-math", "version": "0.2.2" }
   ]
 }


### PR DESCRIPTION
## 基础信息

- 名称: 数学扩展
- 包名: yank-note-extension-math
- 版本: 0.2.2
- 项目地址: https://github.com/MirionQs/yank-note-extension-math