### PR TITLE
update yank-note-extension-math to v0.3.1

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -30,7 +30,7 @@
     { "id": "yank-note-extension-tool-bar", "version": "1.0.0" },
     { "id": "yank-note-extension-snippet", "version": "1.0.3" },
     { "id": "yank-note-extension-docsify", "version": "0.0.3" },
-    { "id": "yank-note-extension-math", "version": "0.3.0" },
+    { "id": "yank-note-extension-math", "version": "0.3.1" },
     { "id": "yank-note-extension-background", "version": "1.0.1" }
   ]
 }


### PR DESCRIPTION
## 基础信息

- 名称: 数学扩展
- 包名: yank-note-extension-math
- 版本: 0.3.1
- 项目地址: https://github.com/MirionQs/yank-note-extension-math

## 更新日志

增强用户体验