### PR TITLE
add new extension: word statistic

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -34,6 +34,7 @@
     { "id": "yank-note-extension-snippet", "version": "1.0.3" },
     { "id": "yank-note-extension-docsify", "version": "0.0.3" },
     { "id": "yank-note-extension-math", "version": "0.3.3" },
-    { "id": "yank-note-extension-background", "version": "1.0.3" }
+    { "id": "yank-note-extension-background", "version": "1.0.3" },
+    { "id": "yank-note-extension-word-statistic", "version": "0.0.1" }
   ]
 }


### PR DESCRIPTION
## 基础信息

- 名称: 字数统计
- 包名: yank-note-extension-word-statistic
- 版本: 0.0.1
- 项目地址: https://github.com/papudding/yank-note-extension-word-statistic

## 更新日志
### 0.0.1 (2025)
#### Features
- 汉字统计 
- 全角标点统计
- 英文字母统计
- 数字统计

## 相关提交
[feat: 添加字数统计插件支持](https://github.com/papudding/yank-note-extension-word-statistic/commit/75e9c28c079e8e36be32436d1f8215c5fb353621)