### PR TITLE
word statistic extension upgrade to 0.0.2

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -35,6 +35,6 @@
     { "id": "yank-note-extension-docsify", "version": "0.0.3" },
     { "id": "yank-note-extension-math", "version": "0.3.3" },
     { "id": "yank-note-extension-background", "version": "1.0.3" },
-    { "id": "yank-note-extension-word-statistic", "version": "0.0.1" }
+    { "id": "yank-note-extension-word-statistic", "version": "0.0.2" }
   ]
 }


### PR DESCRIPTION
## 基础信息

- 名称: 字数统计
- 包名: yank-note-extension-word-statistic
- 版本: 0.0.2
- 项目地址: https://github.com/papudding/yank-note-extension-word-statistic

## 更新日志
### 0.0.2 (2025-04-18)
#### Fix
- 插件安装后尚未配置时，统计信息没有显示的问题
#### Features
- 鼠标移动到统计上变成“小手”		
- 修改配置后实时生效，不用再重启应用

## 相关提交
[refactor(组件): 重构WordStatistic和StatisticManage组件以使用props传递设置](https://github.com/papudding/yank-note-extension-word-statistic/commit/1781d1fe5f4b2ef35a2851e2482cdbd28d4b9ae8)
