### PR TITLE
word statistic extension upgrade to 0.0.3

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -35,7 +35,7 @@
     { "id": "yank-note-extension-docsify", "version": "0.0.3" },
     { "id": "yank-note-extension-math", "version": "0.3.3" },
     { "id": "yank-note-extension-background", "version": "1.0.3" },
-    { "id": "yank-note-extension-word-statistic", "version": "0.0.2" },
+    { "id": "yank-note-extension-word-statistic", "version": "0.0.3" },
     { "id": "yank-note-extension-directory-tree", "version": "0.0.2" }
   ]
 }


### PR DESCRIPTION
## 基础信息

- 名称: 字数统计
- 包名: yank-note-extension-word-statistic
- 版本: 0.0.3
- 项目地址: https://github.com/papudding/yank-note-extension-word-statistic

## 更新日志
### 0.0.3 (2025-05-23)
#### Features
- 增加词云功能		

## 相关提交
[feat(词云): 增加词云功能并优化相关配置](https://github.com/papudding/yank-note-extension-word-statistic/commit/6817d1b1a4440c0d117dd85fc097de3c94756ace)
[feat: 添加词云功能并集成到状态栏工具](https://github.com/papudding/yank-note-extension-word-statistic/commit/d5d09fa005f5723cf71c400f4bcff60e4f6b2a49)