### PR TITLE
word statistic extension upgrade to 0.0.4

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -35,7 +35,7 @@
     { "id": "yank-note-extension-docsify", "version": "0.0.3" },
     { "id": "yank-note-extension-math", "version": "0.3.3" },
     { "id": "yank-note-extension-background", "version": "1.0.3" },
-    { "id": "yank-note-extension-word-statistic", "version": "0.0.3" },
+    { "id": "yank-note-extension-word-statistic", "version": "0.0.4" },
     { "id": "yank-note-extension-directory-tree", "version": "0.0.2" }
   ]
 }


### PR DESCRIPTION
## 基础信息

- 名称: 字数统计
- 包名: yank-note-extension-word-statistic
- 版本: 0.0.4
- 项目地址: https://github.com/papudding/yank-note-extension-word-statistic

## 更新日志
- 修复README图片展示问题	
- 修复打包问题
