### PR TITLE
word statistic extension upgrade to 0.0.5

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -35,7 +35,7 @@
     { "id": "yank-note-extension-docsify", "version": "0.0.3" },
     { "id": "yank-note-extension-math", "version": "0.3.3" },
     { "id": "yank-note-extension-background", "version": "1.0.3" },
-    { "id": "yank-note-extension-word-statistic", "version": "0.0.4" },
+    { "id": "yank-note-extension-word-statistic", "version": "0.0.5" },
     { "id": "yank-note-extension-directory-tree", "version": "0.0.2" }
   ]
 }


### PR DESCRIPTION
## 基础信息

- 名称: 字数统计
- 包名: yank-note-extension-word-statistic
- 版本: 0.0.5
- 项目地址: https://github.com/papudding/yank-note-extension-word-statistic

## 更新日志
### 0.0.5 (2025-05-27)
- (词云)允许增加自定义词
- (词云)增加“排除”按钮，可以排除快速排除候选词
- (统计)增加段落统计

## 相关提交
[feat: 添加段落统计功能并增强词云功能](https://github.com/papudding/yank-note-extension-word-statistic/commit/57257e93e3790414a4f5ed773fc68ff7385418b4)